### PR TITLE
Update ACM bootstrap.sh to not start services

### DIFF
--- a/packer/acm/acm.pkr.hcl
+++ b/packer/acm/acm.pkr.hcl
@@ -30,7 +30,7 @@ packer {
 
 source "amazon-ebs" "ubuntu" {
   ami_name      = local.ami_name
-  instance_type = "t2.micro"
+  instance_type = "t2.medium"
   region        = var.region
   source_ami_filter {
     filters = {

--- a/packer/acm/bootstrap.sh
+++ b/packer/acm/bootstrap.sh
@@ -26,21 +26,16 @@ sudo apt-get update
 echo "Install Clickhouse"
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y clickhouse-server clickhouse-client
 
-echo "Start Clickhouse"
-sudo service clickhouse-server start
+echo "Enable Clickhouse to start at boot"
 sudo systemctl enable clickhouse-server
 
 echo "Install NGINX OSS"
 sudo apt-get install -y nginx
 
-echo "Install NIM"
-sudo apt-get install -y nms-instance-manager
-
 echo "Install ACM"
 sudo apt-get install -y nms-api-connectivity-manager
 
-echo "Enable & start NMS services"
-sudo systemctl start nms
+echo "Enable NMS services to start at boot"
 sudo systemctl enable nms
 ps aufx | grep nms
 sudo systemctl restart nginx


### PR DESCRIPTION
Starting clickhouse-server and NMS during the AMI packer build is not needed and will corrupt the clickhouse database.  A simple "systemctl enable" is all that's needed to automatically generate a fresh database when the AMI is deployed.

Also, NIM is a dependency for ACM so there is no need to install NIM independently.