### PR TITLE
Remove NGINX repo PPA after software install

### DIFF
--- a/packer/acm/bootstrap.sh
+++ b/packer/acm/bootstrap.sh
@@ -53,3 +53,4 @@ sudo nginx -s reload
 echo "Remove NGINX repo cert and key"
 sudo rm /etc/ssl/nginx/nginx-repo.crt
 sudo rm /etc/ssl/nginx/nginx-repo.key
+sudo rm /etc/apt/sources.list.d/nginx-plus.list

--- a/packer/apigw/bootstrap.sh
+++ b/packer/apigw/bootstrap.sh
@@ -19,3 +19,4 @@ sudo apt-get install -y nginx-plus-module-njs
 echo "Remove NGINX repo cert and key"
 sudo rm /etc/ssl/nginx/nginx-repo.crt
 sudo rm /etc/ssl/nginx/nginx-repo.key
+sudo rm /etc/apt/sources.list.d/nginx-plus.list

--- a/packer/devportal/bootstrap.sh
+++ b/packer/devportal/bootstrap.sh
@@ -52,3 +52,4 @@ sudo systemctl start nginx-devportal
 echo "Remove NGINX repo cert and key"
 sudo rm /etc/ssl/nginx/nginx-repo.crt
 sudo rm /etc/ssl/nginx/nginx-repo.key
+sudo rm /etc/apt/sources.list.d/nginx-plus.list


### PR DESCRIPTION
This fixes #3 introduced by #1.  In addition to removing the NGINX repo cert and key, the PPA must also be removed to prevent future `apt update` errors when attempting to install `nginx-agent`.
