### PR TITLE
ACM now requires t3.medium instead of t3.micro

### DIFF
--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -37,7 +37,7 @@ resource "aws_security_group" "acm" {
 
 resource "aws_instance" "acm" {
   ami                    = var.acm_ami
-  instance_type          = "t3.micro"
+  instance_type          = "t3.medium"
   key_name               = aws_key_pair.ssh_access.key_name
   subnet_id              = module.vpc.public_subnets[0]
   vpc_security_group_ids = [aws_security_group.acm.id]


### PR DESCRIPTION
The ACM VM will run out of memory on t3.micro so now a t3.medium VM is required.  This requirement is listed in the ACM docs.